### PR TITLE
Add WebUI port to readme-vars

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -14,6 +14,21 @@ available_architectures:
   - { arch: "{{ arch_arm64 }}", tag: "arm64v8-latest"}
   - { arch: "{{ arch_armhf }}", tag: "arm32v7-latest"}
 
+# optional block 1
+optional_block_1: true
+optional_block_1_items:
+  - |
+    #### Host vs. Bridge
+
+    Home Assistant can [discover][hb0] and automatically configure
+    [zeroconf][hb1]/[mDNS][hb2] and [UPnP][hb3] devices on your network. In
+    order for this to work you must create the container with `--net=host`.
+
+    [hb0]: https://www.home-assistant.io/integrations/discovery/#mdns-and-upnp
+    [hb1]: https://en.wikipedia.org/wiki/Zero-configuration_networking
+    [hb2]: https://en.wikipedia.org/wiki/Multicast_DNS
+    [hb3]: https://en.wikipedia.org/wiki/Universal_Plug_and_Play
+
 # container parameters
 param_container_name: "{{ project_name }}"
 param_usage_include_vols: true
@@ -29,6 +44,11 @@ param_net_desc: "Shares host networking with container. Required for some device
 param_device_map: true
 param_devices:
   - { device_path: "/path/to/device", device_host_path: "/path/to/device", desc: "For passing through USB, serial or gpio devices." }
+
+# optional container parameters
+opt_param_usage_include_ports: true
+opt_param_ports:
+  - { external_port: "8123", internal_port: "8123", port_desc: "Application WebUI, only use this if you are not using host mode." }
 
 # application setup block
 app_setup_block_enabled: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-homeassistant/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Adds port information to `readme-var.yml` so that the README has more complete information.

## Benefits of this PR and context:
While setting this up I followed the examples but couldn't connect to the web ui because the port wasn't included, I had to go back and add it in manually after the fact. This would make it work on the first go around.

## How Has This Been Tested?
I ran the [jenkins builder](https://github.com/linuxserver/docker-jenkins-builder#running-against-local-project) locally and verified the README.md is correct


## Source / References:
closes #11
