### PR TITLE
Resolve dependency conflicts in HA 2022.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,15 +78,15 @@ RUN \
   distlib && \
  pip install --no-cache-dir --upgrade \
   cython \
-  pip==20.2 \
+  pip==21.1.3 \
   setuptools==57.5.0 \
   wheel && \
  cd /tmp/core && \
  pip install ${PIPFLAGS} \
   homeassistant==${HASS_RELEASE} && \
- pip install ${PIPFLAGS} \
+ pip install ${PIPFLAGS} --use-deprecated=legacy-resolver \
   -r requirements_all.txt && \
- pip install ${PIPFLAGS} \
+ pip install ${PIPFLAGS} --use-deprecated=legacy-resolver \
   -r https://raw.githubusercontent.com/home-assistant/docker/${HASS_BASE}/requirements.txt && \
  echo "**** cleanup ****" && \
  apk del --purge \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -77,15 +77,15 @@ RUN \
   distlib && \
  pip install --no-cache-dir --upgrade \
   cython \
-  pip==20.2 \
+  pip==21.1.3 \
   setuptools==57.5.0 \
   wheel && \
  cd /tmp/core && \
  pip install ${PIPFLAGS} \
   homeassistant==${HASS_RELEASE} && \
- pip install ${PIPFLAGS} \
+ pip install ${PIPFLAGS} --use-deprecated=legacy-resolver \
   -r requirements_all.txt && \
- pip install ${PIPFLAGS} \
+ pip install ${PIPFLAGS} --use-deprecated=legacy-resolver \
   -r https://raw.githubusercontent.com/home-assistant/docker/${HASS_BASE}/requirements.txt && \
  echo "**** cleanup ****" && \
  apk del --purge \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -83,15 +83,15 @@ RUN \
   distlib && \
  pip install --no-cache-dir --upgrade \
   cython \
-  pip==20.2 \
+  pip==21.1.3 \
   setuptools==57.5.0 \
   wheel && \
  cd /tmp/core && \
  pip install ${PIPFLAGS} \
   homeassistant==${HASS_RELEASE} && \
- pip install ${PIPFLAGS} \
+ pip install ${PIPFLAGS} --use-deprecated=legacy-resolver \
   -r requirements_all.txt --no-binary grpcio && \
- pip install ${PIPFLAGS} \
+ pip install ${PIPFLAGS} --use-deprecated=legacy-resolver \
   -r https://raw.githubusercontent.com/home-assistant/docker/${HASS_BASE}/requirements.txt && \
  echo "**** cleanup ****" && \
  apk del --purge \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -61,6 +61,7 @@ unraid_template_sync: false
 
 # changelog
 changelogs:
+  - { date: "02.03.22:", desc: "Sync pip version with HA, use legacy dependency resolver to support 2022.3.0+" }
   - { date: "04.02.22:", desc: "Always compile grpcio on arm32v7 due to pypi pushing a glibc only wheel." }
   - { date: "12.12.21:", desc: "Use the new `build.yaml` to determine HA base version." }
   - { date: "25.09.21:", desc: "Use the new lsio homeassistant wheel repo, instead of the HA wheels." }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-homeassistant/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Builds for 2022.3.0 are failing due to dependency conflicts in the HA requirements. Using the `--use-deprecated=legacy-resolver` that HA employs resolve the dependency conflicts and builds a working image for me locally. The pip version is now in sync with HA's pip as well.

## Benefits of this PR and context:
Builds are failing and new images can't be created without this update.

## How Has This Been Tested?
Built the ARM64 version of the image locally, able to run my HA install with it.


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
