### PR TITLE
create secondary venv in `/config` for pip installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ LABEL maintainer="saarg, roxedus"
 ENV \
   PATH="/config/lsiopy/bin:${PATH}" \
   PIPFLAGS="--no-cache-dir --find-links https://wheel-index.linuxserver.io/alpine-3.18/ --find-links https://wheel-index.linuxserver.io/homeassistant-3.18/" \
-  PYTHONPATH="/config/lsiopy/lib/python3.11/site-packages:/lsiopy/lib/python3.11/site-packages"
+  PYTHONPATH="/config/lsiopy/lib/python3.11/site-packages:/lsiopy/lib/python3.11/site-packages" \
+  PIP_DISABLE_PIP_VERSION_CHECK=1
 
 # copy local files
 COPY root/ /

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,9 @@ LABEL maintainer="saarg, roxedus"
 
 # environment settings
 ENV \
+  PATH="/config/lsiopy/bin:${PATH}" \
   PIPFLAGS="--no-cache-dir --find-links https://wheel-index.linuxserver.io/alpine-3.18/ --find-links https://wheel-index.linuxserver.io/homeassistant-3.18/" \
-  PYTHONPATH="${PYTHONPATH}:/pip-packages"
+  PYTHONPATH="/config/lsiopy/lib/python3.11/site-packages:/lsiopy/lib/python3.11/site-packages"
 
 # copy local files
 COPY root/ /
@@ -78,7 +79,6 @@ RUN \
   HASS_BASE=$(cat /tmp/core/build.yaml \
     | grep 'amd64: ' \
     | cut -d: -f3) && \
-  mkdir -p /pip-packages && \
   python3 -m venv /lsiopy && \
   pip install --no-cache-dir --upgrade \
     cython \
@@ -94,6 +94,7 @@ RUN \
     -r https://raw.githubusercontent.com/home-assistant/docker/${HASS_BASE}/requirements.txt && \
   pip install ${PIPFLAGS} \
     -r requirements_all.txt && \
+  PYTHONPATH="" pip uninstall -y asyncio || : && \
   pip install ${PIPFLAGS} \
     homeassistant==${HASS_RELEASE} && \
   pip install ${PIPFLAGS} \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -10,8 +10,9 @@ LABEL maintainer="saarg, roxedus"
 
 # environment settings
 ENV \
+  PATH="/config/lsiopy/bin:${PATH}" \
   PIPFLAGS="--no-cache-dir --find-links https://wheel-index.linuxserver.io/alpine-3.18/ --find-links https://wheel-index.linuxserver.io/homeassistant-3.18/" \
-  PYTHONPATH="${PYTHONPATH}:/pip-packages"
+  PYTHONPATH="/config/lsiopy/lib/python3.11/site-packages:/lsiopy/lib/python3.11/site-packages"
 
 # copy local files
 COPY root/ /
@@ -93,6 +94,7 @@ RUN \
     -r https://raw.githubusercontent.com/home-assistant/docker/${HASS_BASE}/requirements.txt && \
   pip install ${PIPFLAGS} \
     -r requirements_all.txt && \
+  PYTHONPATH="" pip uninstall -y asyncio || : && \
   pip install ${PIPFLAGS} \
     homeassistant==${HASS_RELEASE} && \
   pip install ${PIPFLAGS} \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -12,7 +12,8 @@ LABEL maintainer="saarg, roxedus"
 ENV \
   PATH="/config/lsiopy/bin:${PATH}" \
   PIPFLAGS="--no-cache-dir --find-links https://wheel-index.linuxserver.io/alpine-3.18/ --find-links https://wheel-index.linuxserver.io/homeassistant-3.18/" \
-  PYTHONPATH="/config/lsiopy/lib/python3.11/site-packages:/lsiopy/lib/python3.11/site-packages"
+  PYTHONPATH="/config/lsiopy/lib/python3.11/site-packages:/lsiopy/lib/python3.11/site-packages" \
+  PIP_DISABLE_PIP_VERSION_CHECK=1
 
 # copy local files
 COPY root/ /

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **14.06.23:** - Create secondary venv in `/config` for pip installs.
 * **07.06.23:** - Rebase to alpine 3.18, switch to cp311 wheels.
 * **03.05.23:** - Deprecate arm32v7. Latest HA version with an arm32v7 build is `2023.4.6`.
 * **16.11.22:** - Fix the dep conflict for google calendar.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -61,6 +61,7 @@ unraid_template_sync: false
 
 # changelog
 changelogs:
+  - { date: "14.06.23:", desc: "Create secondary venv in `/config` for pip installs." }
   - { date: "07.06.23:", desc: "Rebase to alpine 3.18, switch to cp311 wheels." }
   - { date: "03.05.23:", desc: "Deprecate arm32v7. Latest HA version with an arm32v7 build is `2023.4.6`." }
   - { date: "16.11.22:", desc: "Fix the dep conflict for google calendar." }

--- a/root/etc/s6-overlay/s6-rc.d/init-config-homeassistant/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-config-homeassistant/run
@@ -3,8 +3,10 @@
 
 # Create secondary venv in /config for pip installs
 if [[ ! -d /config/lsiopy/bin ]]; then
+  echo "Creating venv in /config/lsiopy for runtime use"
   s6-setuidgid abc python3 -m venv /config/lsiopy
 fi
+echo "Updating pip to HA supported version"
 s6-setuidgid abc /config/lsiopy/bin/pip install \
     --no-cache-dir --upgrade \
     "pip>=21.0,<22.1" \
@@ -12,5 +14,6 @@ s6-setuidgid abc /config/lsiopy/bin/pip install \
     wheel
 
 # set permissions
+echo "Setting permissions"
 lsiown -R abc:abc \
     /config

--- a/root/etc/s6-overlay/s6-rc.d/init-config-homeassistant/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-config-homeassistant/run
@@ -1,9 +1,15 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
+# Create secondary venv in /config for pip installs
+if [[ ! -d /config/lsiopy/bin ]]; then
+  mkdir -p /config/lsiopy
+  python3 -m venv /config/lsiopy
+fi
+if ! grep -q '/config/lsiopy/bin' /var/run/s6/container_environment/PATH; then
+  sed -i '1s|^|/config/lsiopy/bin:|' /var/run/s6/container_environment/PATH
+fi
+
 # set permissions
 lsiown -R abc:abc \
     /config
-find /lsiopy -path /lsiopy/lib/python3.11/site-packages -prune -o -exec chown abc:abc {} +
-lsiown abc:abc /lsiopy/lib/python3.11/site-packages
-lsiown -R abc:abc /lsiopy/lib/python3.11/site-packages/{test,tests}

--- a/root/etc/s6-overlay/s6-rc.d/init-config-homeassistant/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-config-homeassistant/run
@@ -3,12 +3,13 @@
 
 # Create secondary venv in /config for pip installs
 if [[ ! -d /config/lsiopy/bin ]]; then
-  mkdir -p /config/lsiopy
-  python3 -m venv /config/lsiopy
+  s6-setuidgid abc python3 -m venv /config/lsiopy
 fi
-if ! grep -q '/config/lsiopy/bin' /var/run/s6/container_environment/PATH; then
-  sed -i '1s|^|/config/lsiopy/bin:|' /var/run/s6/container_environment/PATH
-fi
+s6-setuidgid abc /config/lsiopy/bin/pip install \
+    --no-cache-dir --upgrade \
+    "pip>=21.0,<22.1" \
+    setuptools \
+    wheel
 
 # set permissions
 lsiown -R abc:abc \


### PR DESCRIPTION
- Creates a second venv in the `/config` folder and makes it the primary via `PATH`
- Adds the original venv to `PYTHONPATH` so secondary pip has access to HA dep packages
- New package installs should go to the second venv in the `/config` folder, it's chowned and no perm issues
- Pip does not have to attempt to remove existing packages from the original venv so no perm issues
- Had to manually and forcefully remove `asyncio`, a deprecated external package that has been integrated into python-core back in py3.4, but a couple of HA deps list it in their deps, which breaks pip when its location is included in `PYTHONPATH`
  - Submitted PR to `pyElectra` for removal of the dep: https://github.com/jafar-atili/pyElectra/pull/2
  - `goslide-api` already removed the dep in later versions but HA pins an older version where it's still in requirements

needs some local testing

hopefully mitigates #70 