### PR TITLE
Rebase to alpine 3.19 and python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -194,7 +194,9 @@ RUN \
   LD_PRELOAD="/usr/local/lib/libjemalloc.so.2" \
     MALLOC_CONF="background_thread:true,metadata_thp:auto,dirty_decay_ms:20000,muzzy_decay_ms:20000" \
     pip3 install --only-binary=:all: \
-      -r requirements_all.txt && \
+      -r requirements_all.txt \
+      isal \
+      pycups==${PYCUPS_VER} && \
   pip3 install \
     homeassistant==${HASS_RELEASE} && \
   for cleanfiles in *.pyc *.pyo; do \

--- a/Dockerfile
+++ b/Dockerfile
@@ -191,6 +191,7 @@ RUN \
     -r https://raw.githubusercontent.com/home-assistant/docker/${HASS_BASE}/requirements.txt && \
   pip3 install --only-binary=:all: \
     -r requirements.txt && \
+  PYCUPS_VER=$(grep "pycups" requirements_all.txt | sed 's|.*==||') && \
   LD_PRELOAD="/usr/local/lib/libjemalloc.so.2" \
     MALLOC_CONF="background_thread:true,metadata_thp:auto,dirty_decay_ms:20000,muzzy_decay_ms:20000" \
     pip3 install --only-binary=:all: \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,49 +1,54 @@
-FROM ghcr.io/linuxserver/baseimage-alpine:3.18
+# syntax=docker/dockerfile:1
+
+FROM ghcr.io/linuxserver/baseimage-alpine:3.19
 
 # set version label
 ARG BUILD_DATE
 ARG VERSION
 ARG HASS_RELEASE
-ARG HACS_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="saarg, roxedus"
 
-# environment settings
 ENV \
-  PATH="/config/lsiopy/bin:${PATH}" \
-  PIPFLAGS="--no-cache-dir --find-links https://wheel-index.linuxserver.io/alpine-3.18/ --find-links https://wheel-index.linuxserver.io/homeassistant-3.18/" \
-  PYTHONPATH="/config/lsiopy/lib/python3.11/site-packages:/lsiopy/lib/python3.11/site-packages" \
-  PIP_DISABLE_PIP_VERSION_CHECK=1
+  S6_SERVICES_GRACETIME=240000
 
-# copy local files
-COPY root/ /
+COPY root/etc/pip.conf /etc/
 
 # install packages
 RUN \
   echo "**** install build packages ****" && \
   apk add --no-cache --virtual=build-dependencies \
     autoconf \
-    ca-certificates \
-    cargo \
-    cmake \
-    cups-dev \
-    eudev-dev \
-    ffmpeg-dev \
-    gcc \
-    glib-dev \
-    g++ \
-    jq \
+    patch \
+    bzip2-dev \
+    coreutils \
+    dpkg-dev dpkg \
+    expat-dev \
+    findutils \
+    build-base \
+    gdbm-dev \
+    libc-dev \
     libffi-dev \
-    jpeg-dev \
-    libxml2-dev \
-    libxslt-dev \
+    libnsl-dev \
+    openssl \
+    openssl-dev \
+    libtirpc-dev \
+    linux-headers \
     make \
-    postgresql-dev \
-    python3-dev \
-    unixodbc-dev \
-    unzip && \
+    mpdecimal-dev \
+    ncurses-dev \
+    pax-utils \
+    readline-dev \
+    sqlite-dev \
+    tcl-dev \
+    tk \
+    tk-dev \
+    xz-dev \
+    zlib-dev \
+    bluez-dev && \
   echo "**** install runtime packages ****" && \
   apk add --no-cache \
+    bind-tools \
     bluez \
     bluez-deprecated \
     bluez-libs \
@@ -51,20 +56,31 @@ RUN \
     curl \
     eudev-libs \
     ffmpeg \
+    git \
+    hwdata-usb \
+    imlib2 \
+    iperf3 \
     iputils \
     libcap \
-    libjpeg-turbo \
+    libftdi1 \
+    libgpiod \
+    libturbojpeg \
+    libpulse \
     libstdc++ \
     libxslt \
+    libzbar \
     mariadb-connector-c \
-    mariadb-connector-c-dev \
+    net-tools \
+    nmap \
     openssh-client \
     openssl \
+    pianobar \
     postgresql-libs \
-    py3-pip \
-    python3 \
-    tiff && \
-  echo "**** install homeassistant ****" && \
+    pulseaudio-alsa \
+    socat \
+    tiff \
+    xz && \
+  echo "**** Retrieve versions ****" && \
   mkdir -p \
     /tmp/core && \
   if [ -z ${HASS_RELEASE+x} ]; then \
@@ -80,34 +96,113 @@ RUN \
   HASS_BASE=$(cat /tmp/core/build.yaml \
     | grep 'amd64: ' \
     | cut -d: -f3) && \
-  python3 -m venv /lsiopy && \
-  pip install --no-cache-dir --upgrade \
-    cython \
-    "pip>=21.0,<22.1" \
-    pyparsing \
-    setuptools \
-    wheel && \
+  HA_PY_MAJOR=$(curl -fsL https://raw.githubusercontent.com/home-assistant/docker/${HASS_BASE}/build.yaml \
+    | grep 'amd64: ' \
+    | cut -d: -f3 \
+    | sed 's|-alpine.*||') && \
+  HA_DOCKER_BASE=$(curl -sX GET https://api.github.com/repos/home-assistant/docker-base/releases/latest \
+      | jq -r .tag_name) && \
+  git clone --branch "${HA_DOCKER_BASE}" \
+    --depth 1 https://github.com/home-assistant/docker-base.git \
+    /tmp/ha-docker-base && \
+  HA_PY_VERSION=$(cat /tmp/ha-docker-base/python/${HA_PY_MAJOR}/build.yaml \
+    | grep 'PYTHON_VERSION: ' \
+    | sed 's|.*PYTHON_VERSION: ||') && \
+  HA_JEMALLOC_VER=$(cat /tmp/ha-docker-base/alpine/build.yaml \
+    | grep 'JEMALLOC_VERSION: ' \
+    | sed 's|.*JEMALLOC_VERSION: ||') && \
+  HA_ALPINE_VER=$(curl -fsL https://raw.githubusercontent.com/home-assistant/docker/${HASS_BASE}/build.yaml \
+    | grep 'amd64: ' \
+    | cut -d: -f3 \
+    | sed 's|.*-alpine||') && \
+  IMAGE_ALPINE_VER=$(cat /etc/os-release | grep PRETTY_NAME | sed 's|.*Linux v||' | sed 's|"||') && \
+  if [[ "${HA_ALPINE_VER}" != "${IMAGE_ALPINE_VER}" ]]; then \
+    echo -e "**** Incorrect OS version detected, canceling build ****\n**** Upstream expected OS: ${HA_ALPINE_VER} ****\n**** Detected OS: ${IMAGE_ALPINE_VER}****"; \
+    exit 1; \
+  fi && \
+  HA_PIP_VERSION=$(cat /tmp/ha-docker-base/python/${HA_PY_MAJOR}/build.yaml \
+    | grep 'PIP_VERSION: ' \
+    | sed 's|.*PIP_VERSION: ||') && \
+  echo "**** install jemalloc ****" && \
+  git clone --branch ${HA_JEMALLOC_VER} \
+    --depth 1 "https://github.com/jemalloc/jemalloc" \
+    /tmp/jemalloc && \
+  cd /tmp/jemalloc && \
+  ./autogen.sh \
+    --with-lg-page=16 && \
+  make -j "$(nproc)" && \
+  make install_lib_shared install_bin && \
+  echo "**** install python ****" && \
+  mkdir -p /tmp/python && \
+  curl -o \
+    /tmp/python.tar.xz -L \
+    "https://www.python.org/ftp/python/${HA_PY_VERSION}/Python-${HA_PY_VERSION}.tar.xz" && \
+  tar xf \
+    /tmp/python.tar.xz -C \
+    /tmp/python --strip-components=1 && \
+  for patch in /tmp/ha-docker-base/python/${HA_PY_MAJOR}/*.patch; do \
+    patch -d /tmp/python -p 1 < "${patch}"; \
+  done && \
+  cd /tmp/python && \
+  ./configure \
+    --build="x86_64-linux-musl" \
+    --enable-loadable-sqlite-extensions \
+    --enable-optimizations \
+    --enable-option-checking=fatal \
+    --enable-shared \
+    --with-lto \
+    --with-system-libmpdec \
+    --with-system-expat \
+    --without-ensurepip \
+    --without-static-libpython && \
+  make -j "$(nproc)" \
+    LDFLAGS="-Wl,--strip-all" \
+    CFLAGS="-fno-semantic-interposition -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free" \
+    EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" && \
+  make install && \
+  find /usr/local -type f -executable -not \( -name '*tkinter*' \) -exec scanelf --needed --nobanner --format '%n#p' '{}' ';' \
+		| tr ',' '\n' \
+		| sort -u \
+		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+		| xargs -rt apk add --no-cache --virtual .python-rundeps && \
+  find /usr/local -depth \
+    \( \
+        -type d -a \( -name test -o -name tests \) \
+    \) -exec rm -rf '{}' + && \
+  cd /usr/local/bin && \
+  ln -s idle3 idle && \
+  ln -s pydoc3 pydoc && \
+  ln -s python3 python && \
+  ln -s python3-config python-config && \
+  curl -o \
+    /tmp/get-pip.py -L \
+    "https://bootstrap.pypa.io/get-pip.py" && \
+  /usr/local/bin/python3 /tmp/get-pip.py \
+    --disable-pip-version-check \
+    --no-cache-dir \
+    pip==${HA_PIP_VERSION} && \
+  find /usr/local -depth \
+    \( \
+        -type d -a \( -name test -o -name tests \) \
+    \) -exec rm -rf '{}' + && \
+  echo "**** install homeassistant ****" && \
   cd /tmp/core && \
-  NUMPY_VER=$(grep "numpy" requirements_all.txt) && \
-  PYCUPS_VER=$(grep "pycups" requirements_all.txt | sed 's|.*==||') && \
-  pip install ${PIPFLAGS} \
-    "${NUMPY_VER}" && \
-  pip install ${PIPFLAGS} \
+  pip3 install --only-binary=:all: \
     -r https://raw.githubusercontent.com/home-assistant/docker/${HASS_BASE}/requirements.txt && \
-  pip install ${PIPFLAGS} \
-    -r requirements_all.txt && \
-  PYTHONPATH="" pip uninstall -y asyncio || : && \
-  pip install ${PIPFLAGS} \
-    pycups==${PYCUPS_VER} && \
-  pip install ${PIPFLAGS} \
+  pip3 install --only-binary=:all: \
+    -r requirements.txt && \
+  LD_PRELOAD="/usr/local/lib/libjemalloc.so.2" \
+    MALLOC_CONF="background_thread:true,metadata_thp:auto,dirty_decay_ms:20000,muzzy_decay_ms:20000" \
+    pip3 install --only-binary=:all: \
+      -r requirements_all.txt && \
+  pip3 install \
     homeassistant==${HASS_RELEASE} && \
+  for cleanfiles in *.pyc *.pyo; do \
+    find /usr/local/lib/python3.*  -iname "${cleanfiles}" -exec rm -f '{}' + ; \
+  done && \
   echo "**** cleanup ****" && \
   apk del --purge \
     build-dependencies && \
-  for cleanfiles in *.pyc *.pyo; \
-    do \
-    find /lsiopy/lib/python3.*  -iname "${cleanfiles}" -exec rm -f '{}' + \
-    ; done && \
   rm -rf \
     /tmp/* \
     /root/.cache \
@@ -115,6 +210,9 @@ RUN \
 
 # environment settings. used so pip packages installed by home assistant installs in /config
 ENV HOME="/config"
+
+# copy local files
+COPY root/ /
 
 # ports and volumes
 EXPOSE 8123

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,49 +1,54 @@
-FROM ghcr.io/linuxserver/baseimage-alpine:arm64v8-3.18
+# syntax=docker/dockerfile:1
+
+FROM ghcr.io/linuxserver/baseimage-alpine:arm64v8-3.19
 
 # set version label
 ARG BUILD_DATE
 ARG VERSION
 ARG HASS_RELEASE
-ARG HACS_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="saarg, roxedus"
 
-# environment settings
 ENV \
-  PATH="/config/lsiopy/bin:${PATH}" \
-  PIPFLAGS="--no-cache-dir --find-links https://wheel-index.linuxserver.io/alpine-3.18/ --find-links https://wheel-index.linuxserver.io/homeassistant-3.18/" \
-  PYTHONPATH="/config/lsiopy/lib/python3.11/site-packages:/lsiopy/lib/python3.11/site-packages" \
-  PIP_DISABLE_PIP_VERSION_CHECK=1
+  S6_SERVICES_GRACETIME=240000
 
-# copy local files
-COPY root/ /
+COPY root/etc/pip.conf /etc/
 
 # install packages
 RUN \
   echo "**** install build packages ****" && \
   apk add --no-cache --virtual=build-dependencies \
     autoconf \
-    ca-certificates \
-    cargo \
-    cmake \
-    cups-dev \
-    eudev-dev \
-    ffmpeg-dev \
-    gcc \
-    glib-dev \
-    g++ \
-    jq \
+    patch \
+    bzip2-dev \
+    coreutils \
+    dpkg-dev dpkg \
+    expat-dev \
+    findutils \
+    build-base \
+    gdbm-dev \
+    libc-dev \
     libffi-dev \
-    jpeg-dev \
-    libxml2-dev \
-    libxslt-dev \
+    libnsl-dev \
+    openssl \
+    openssl-dev \
+    libtirpc-dev \
+    linux-headers \
     make \
-    postgresql-dev \
-    python3-dev \
-    unixodbc-dev \
-    unzip && \
+    mpdecimal-dev \
+    ncurses-dev \
+    pax-utils \
+    readline-dev \
+    sqlite-dev \
+    tcl-dev \
+    tk \
+    tk-dev \
+    xz-dev \
+    zlib-dev \
+    bluez-dev && \
   echo "**** install runtime packages ****" && \
   apk add --no-cache \
+    bind-tools \
     bluez \
     bluez-deprecated \
     bluez-libs \
@@ -51,20 +56,31 @@ RUN \
     curl \
     eudev-libs \
     ffmpeg \
+    git \
+    hwdata-usb \
+    imlib2 \
+    iperf3 \
     iputils \
     libcap \
-    libjpeg-turbo \
+    libftdi1 \
+    libgpiod \
+    libturbojpeg \
+    libpulse \
     libstdc++ \
     libxslt \
+    libzbar \
     mariadb-connector-c \
-    mariadb-connector-c-dev \
+    net-tools \
+    nmap \
     openssh-client \
     openssl \
+    pianobar \
     postgresql-libs \
-    py3-pip \
-    python3 \
-    tiff && \
-  echo "**** install homeassistant ****" && \
+    pulseaudio-alsa \
+    socat \
+    tiff \
+    xz && \
+  echo "**** Retrieve versions ****" && \
   mkdir -p \
     /tmp/core && \
   if [ -z ${HASS_RELEASE+x} ]; then \
@@ -80,34 +96,113 @@ RUN \
   HASS_BASE=$(cat /tmp/core/build.yaml \
     | grep 'amd64: ' \
     | cut -d: -f3) && \
-  python3 -m venv /lsiopy && \
-  pip install --no-cache-dir --upgrade \
-    cython \
-    "pip>=21.0,<22.1" \
-    pyparsing \
-    setuptools \
-    wheel && \
+  HA_PY_MAJOR=$(curl -fsL https://raw.githubusercontent.com/home-assistant/docker/${HASS_BASE}/build.yaml \
+    | grep 'amd64: ' \
+    | cut -d: -f3 \
+    | sed 's|-alpine.*||') && \
+  HA_DOCKER_BASE=$(curl -sX GET https://api.github.com/repos/home-assistant/docker-base/releases/latest \
+      | jq -r .tag_name) && \
+  git clone --branch "${HA_DOCKER_BASE}" \
+    --depth 1 https://github.com/home-assistant/docker-base.git \
+    /tmp/ha-docker-base && \
+  HA_PY_VERSION=$(cat /tmp/ha-docker-base/python/${HA_PY_MAJOR}/build.yaml \
+    | grep 'PYTHON_VERSION: ' \
+    | sed 's|.*PYTHON_VERSION: ||') && \
+  HA_JEMALLOC_VER=$(cat /tmp/ha-docker-base/alpine/build.yaml \
+    | grep 'JEMALLOC_VERSION: ' \
+    | sed 's|.*JEMALLOC_VERSION: ||') && \
+  HA_ALPINE_VER=$(curl -fsL https://raw.githubusercontent.com/home-assistant/docker/${HASS_BASE}/build.yaml \
+    | grep 'amd64: ' \
+    | cut -d: -f3 \
+    | sed 's|.*-alpine||') && \
+  IMAGE_ALPINE_VER=$(cat /etc/os-release | grep PRETTY_NAME | sed 's|.*Linux v||' | sed 's|"||') && \
+  if [[ "${HA_ALPINE_VER}" != "${IMAGE_ALPINE_VER}" ]]; then \
+    echo -e "**** Incorrect OS version detected, canceling build ****\n**** Upstream expected OS: ${HA_ALPINE_VER} ****\n**** Detected OS: ${IMAGE_ALPINE_VER}****"; \
+    exit 1; \
+  fi && \
+  HA_PIP_VERSION=$(cat /tmp/ha-docker-base/python/${HA_PY_MAJOR}/build.yaml \
+    | grep 'PIP_VERSION: ' \
+    | sed 's|.*PIP_VERSION: ||') && \
+  echo "**** install jemalloc ****" && \
+  git clone --branch ${HA_JEMALLOC_VER} \
+    --depth 1 "https://github.com/jemalloc/jemalloc" \
+    /tmp/jemalloc && \
+  cd /tmp/jemalloc && \
+  ./autogen.sh \
+    --with-lg-page=16 && \
+  make -j "$(nproc)" && \
+  make install_lib_shared install_bin && \
+  echo "**** install python ****" && \
+  mkdir -p /tmp/python && \
+  curl -o \
+    /tmp/python.tar.xz -L \
+    "https://www.python.org/ftp/python/${HA_PY_VERSION}/Python-${HA_PY_VERSION}.tar.xz" && \
+  tar xf \
+    /tmp/python.tar.xz -C \
+    /tmp/python --strip-components=1 && \
+  for patch in /tmp/ha-docker-base/python/${HA_PY_MAJOR}/*.patch; do \
+    patch -d /tmp/python -p 1 < "${patch}"; \
+  done && \
+  cd /tmp/python && \
+  ./configure \
+    --build="aarch64-linux-musl" \
+    --enable-loadable-sqlite-extensions \
+    --enable-optimizations \
+    --enable-option-checking=fatal \
+    --enable-shared \
+    --with-lto \
+    --with-system-libmpdec \
+    --with-system-expat \
+    --without-ensurepip \
+    --without-static-libpython && \
+  make -j "$(nproc)" \
+    LDFLAGS="-Wl,--strip-all" \
+    CFLAGS="-fno-semantic-interposition -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free" \
+    EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" && \
+  make install && \
+  find /usr/local -type f -executable -not \( -name '*tkinter*' \) -exec scanelf --needed --nobanner --format '%n#p' '{}' ';' \
+		| tr ',' '\n' \
+		| sort -u \
+		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+		| xargs -rt apk add --no-cache --virtual .python-rundeps && \
+  find /usr/local -depth \
+    \( \
+        -type d -a \( -name test -o -name tests \) \
+    \) -exec rm -rf '{}' + && \
+  cd /usr/local/bin && \
+  ln -s idle3 idle && \
+  ln -s pydoc3 pydoc && \
+  ln -s python3 python && \
+  ln -s python3-config python-config && \
+  curl -o \
+    /tmp/get-pip.py -L \
+    "https://bootstrap.pypa.io/get-pip.py" && \
+  /usr/local/bin/python3 /tmp/get-pip.py \
+    --disable-pip-version-check \
+    --no-cache-dir \
+    pip==${HA_PIP_VERSION} && \
+  find /usr/local -depth \
+    \( \
+        -type d -a \( -name test -o -name tests \) \
+    \) -exec rm -rf '{}' + && \
+  echo "**** install homeassistant ****" && \
   cd /tmp/core && \
-  NUMPY_VER=$(grep "numpy" requirements_all.txt) && \
-  PYCUPS_VER=$(grep "pycups" requirements_all.txt | sed 's|.*==||') && \
-  pip install ${PIPFLAGS} \
-    "${NUMPY_VER}" && \
-  pip install ${PIPFLAGS} \
+  pip3 install --only-binary=:all: \
     -r https://raw.githubusercontent.com/home-assistant/docker/${HASS_BASE}/requirements.txt && \
-  pip install ${PIPFLAGS} \
-    -r requirements_all.txt && \
-  PYTHONPATH="" pip uninstall -y asyncio || : && \
-  pip install ${PIPFLAGS} \
-    pycups==${PYCUPS_VER} && \
-  pip install ${PIPFLAGS} \
+  pip3 install --only-binary=:all: \
+    -r requirements.txt && \
+  LD_PRELOAD="/usr/local/lib/libjemalloc.so.2" \
+    MALLOC_CONF="background_thread:true,metadata_thp:auto,dirty_decay_ms:20000,muzzy_decay_ms:20000" \
+    pip3 install --only-binary=:all: \
+      -r requirements_all.txt && \
+  pip3 install \
     homeassistant==${HASS_RELEASE} && \
+  for cleanfiles in *.pyc *.pyo; do \
+    find /usr/local/lib/python3.*  -iname "${cleanfiles}" -exec rm -f '{}' + ; \
+  done && \
   echo "**** cleanup ****" && \
   apk del --purge \
     build-dependencies && \
-  for cleanfiles in *.pyc *.pyo; \
-    do \
-    find /lsiopy/lib/python3.*  -iname "${cleanfiles}" -exec rm -f '{}' + \
-    ; done && \
   rm -rf \
     /tmp/* \
     /root/.cache \
@@ -115,6 +210,9 @@ RUN \
 
 # environment settings. used so pip packages installed by home assistant installs in /config
 ENV HOME="/config"
+
+# copy local files
+COPY root/ /
 
 # ports and volumes
 EXPOSE 8123

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -191,10 +191,13 @@ RUN \
     -r https://raw.githubusercontent.com/home-assistant/docker/${HASS_BASE}/requirements.txt && \
   pip3 install --only-binary=:all: \
     -r requirements.txt && \
+  PYCUPS_VER=$(grep "pycups" requirements_all.txt | sed 's|.*==||') && \
   LD_PRELOAD="/usr/local/lib/libjemalloc.so.2" \
     MALLOC_CONF="background_thread:true,metadata_thp:auto,dirty_decay_ms:20000,muzzy_decay_ms:20000" \
     pip3 install --only-binary=:all: \
-      -r requirements_all.txt && \
+      -r requirements_all.txt \
+      isal \
+      pycups==${PYCUPS_VER} && \
   pip3 install \
     homeassistant==${HASS_RELEASE} && \
   for cleanfiles in *.pyc *.pyo; do \

--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **07.02.24:** - Rebase to alpine 3.19, upgrade to python 3.12. Restructure python packages so all packages are internal (no more venv in /config). Use upstream project's wheels.
 * **18.12.23:** - Add Bluetooth instructions to readme.
 * **05.07.23:** - Deprecate armhf. As announced [here](https://www.linuxserver.io/blog/a-farewell-to-arm-hf)
 * **21.06.23:** - Pin pycups version.

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
-* **07.02.24:** - Rebase to alpine 3.19, upgrade to python 3.12. Restructure python packages so all packages are internal (no more venv in /config). Use upstream project's wheels.
+* **13.02.24:** - Rebase to alpine 3.19, upgrade to python 3.12. Restructure python packages so all packages are internal (no more venv in /config). Use upstream project's wheels. Due to an upstream issue, on first start of the newly updated container, some custom integrations may be disabled in HA due to missing dependencies. A subsequent container restart should fix that and the integrations should be re-enabled.
 * **18.12.23:** - Add Bluetooth instructions to readme.
 * **05.07.23:** - Deprecate armhf. As announced [here](https://www.linuxserver.io/blog/a-farewell-to-arm-hf)
 * **21.06.23:** - Pin pycups version.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -69,6 +69,7 @@ app_setup_block: |
 unraid_template_sync: false
 # changelog
 changelogs:
+  - {date: "07.02.24:", desc: "Rebase to alpine 3.19, upgrade to python 3.12. Restructure python packages so all packages are internal (no more venv in /config). Use upstream project's wheels."}
   - {date: "18.12.23:", desc: "Add Bluetooth instructions to readme."}
   - {date: "05.07.23:", desc: "Deprecate armhf. As announced [here](https://www.linuxserver.io/blog/a-farewell-to-arm-hf)"}
   - {date: "21.06.23:", desc: "Pin pycups version."}

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -69,7 +69,7 @@ app_setup_block: |
 unraid_template_sync: false
 # changelog
 changelogs:
-  - {date: "07.02.24:", desc: "Rebase to alpine 3.19, upgrade to python 3.12. Restructure python packages so all packages are internal (no more venv in /config). Use upstream project's wheels."}
+  - {date: "13.02.24:", desc: "Rebase to alpine 3.19, upgrade to python 3.12. Restructure python packages so all packages are internal (no more venv in /config). Use upstream project's wheels. Due to an upstream issue, on first start of the newly updated container, some custom integrations may be disabled in HA due to missing dependencies. A subsequent container restart should fix that and the integrations should be re-enabled."}
   - {date: "18.12.23:", desc: "Add Bluetooth instructions to readme."}
   - {date: "05.07.23:", desc: "Deprecate armhf. As announced [here](https://www.linuxserver.io/blog/a-farewell-to-arm-hf)"}
   - {date: "21.06.23:", desc: "Pin pycups version."}

--- a/root/etc/pip.conf
+++ b/root/etc/pip.conf
@@ -1,0 +1,5 @@
+[global]
+disable-pip-version-check = true
+extra-index-url = https://wheels.home-assistant.io/musllinux-index/
+no-cache-dir = true
+prefer-binary = true

--- a/root/etc/s6-overlay/s6-rc.d/init-config-homeassistant/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-config-homeassistant/run
@@ -1,18 +1,6 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
-# Create secondary venv in /config for pip installs
-if [[ ! -d /config/lsiopy/bin ]]; then
-  echo "Creating venv in /config/lsiopy for runtime use"
-  s6-setuidgid abc python3 -m venv /config/lsiopy
-fi
-echo "Updating pip to HA supported version"
-s6-setuidgid abc /config/lsiopy/bin/pip install \
-    --no-cache-dir --upgrade \
-    "pip>=21.0,<22.1" \
-    setuptools \
-    wheel
-
 # set permissions
 echo "Setting permissions"
 lsiown -R abc:abc \

--- a/root/etc/s6-overlay/s6-rc.d/init-config-homeassistant/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-config-homeassistant/run
@@ -1,6 +1,9 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
+# migration
+rm -rf /config/lsiopy
+
 # set permissions
 echo "Setting permissions"
 lsiown -R abc:abc \

--- a/root/etc/s6-overlay/s6-rc.d/init-mods-package-install/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mods-package-install/run
@@ -1,0 +1,24 @@
+#!/usr/bin/with-contenv bash
+# shellcheck shell=bash
+
+if [[ -f "/mod-repo-packages-to-install.list" ]]; then
+    IFS=' ' read -ra REPO_PACKAGES <<< "$(tr '\n' ' ' < /mod-repo-packages-to-install.list)"
+    if [[ ${#REPO_PACKAGES[@]} -ne 0 ]] && [[ ${REPO_PACKAGES[*]} != "" ]]; then
+        echo "[mod-init] **** Installing all mod packages ****"
+        apk add --no-cache \
+            "${REPO_PACKAGES[@]}"
+    fi
+fi
+
+if [[ -f "/mod-pip-packages-to-install.list" ]]; then
+    IFS=' ' read -ra PIP_PACKAGES <<< "$(tr '\n' ' ' < /mod-pip-packages-to-install.list)"
+    if [[ ${#PIP_PACKAGES[@]} -ne 0 ]] && [[ ${PIP_PACKAGES[*]} != "" ]]; then
+        echo "[mod-init] **** Installing all pip packages ****"
+        python3 -m pip install \
+            "${PIP_PACKAGES[@]}"
+    fi
+fi
+
+rm -rf \
+    /mod-repo-packages-to-install.list \
+    /mod-pip-packages-to-install.list

--- a/root/etc/s6-overlay/s6-rc.d/svc-homeassistant/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-homeassistant/run
@@ -1,8 +1,13 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
-setcap 'cap_net_bind_service=+ep' /usr/bin/python3.11
+setcap 'cap_net_bind_service=+ep' /usr/local/bin/python3.12
+
+if [[ -z "${DISABLE_JEMALLOC+x}" ]]; then
+  export LD_PRELOAD="/usr/local/lib/libjemalloc.so.2"
+  export MALLOC_CONF="background_thread:true,metadata_thp:auto,dirty_decay_ms:20000,muzzy_decay_ms:20000"
+fi
 
 exec \
     s6-notifyoncheck -d -n 60 -w 5000 -c "nc -z localhost 8123" \
-    s6-setuidgid abc /config/lsiopy/bin/python3 /lsiopy/bin/hass -c /config
+    s6-setuidgid abc python3 -m homeassistant -c /config


### PR DESCRIPTION
Use upstream wheels instead of lsio ones
Retrieve python, pip and jemalloc versions from upstream and match
Since python is compiled from source instead of os package, we can do away with the venv. New python packages get installed in the /config folder (user home).
Due to doing away with the venv and breaking cadence with lsio wheels, package installer script also has been customized

~~Could use a little more testing in production before merge, but needs to be merged by April as that's when HA drops support for py 3.11~~
Tested update of production instance, no issues.

closes #95 

When merged (or right before), the following needs done:
- Disable the HA wheelie builder (https://github.com/linuxserver/wheelie/blob/main/.github/workflows/wheelie_HA_scheduler.yml)
- Remove the org secret disabling HA external trigger